### PR TITLE
Handle return type in "from_raw".

### DIFF
--- a/custom_components/modbus_devices/devices/datatypes.py
+++ b/custom_components/modbus_devices/devices/datatypes.py
@@ -130,7 +130,12 @@ class ModbusDatapoint:
         # Interpret bytes
         if self.type in ('int', 'uint'):
             combined_value = int.from_bytes(b, byteorder='big', signed=(self.type == 'int'))
-            self.value = combined_value * self.scaling + self.offset
+            calculated_value = combined_value * self.scaling + self.offset
+            # Preserve float only when scaling/offset create a fractional part
+            if calculated_value % 1 != 0:
+                self.value = calculated_value
+            else:
+                self.value = int(calculated_value)
 
         elif self.type == 'float':
             if self.length == 2:


### PR DESCRIPTION
Once again I have tried to make a minimal pull request, hope it's working.

Below is an "improved" version of previous fix (that got lost in last merge). 

This is "critical" since without this fix all integer values will automatically be converted to float since the orignal "self.value" result is float due to part of equation is typed as floats. This will break other parts of code that rely on values actually being integers. 

The change will try to keep integers as integers unless they actually is being actively modified (scaled or offseted) to a float.

This was the thing that broke everything in previous release (and also this release).