### PR TITLE
Suggested improvment in  string handling for from_raw and to_raw

### DIFF
--- a/custom_components/modbus_devices/devices/datatypes.py
+++ b/custom_components/modbus_devices/devices/datatypes.py
@@ -148,10 +148,7 @@ class ModbusDatapoint:
                 self.value = combined_value * self.scaling + self.offset
 
         elif self.type == 'string':
-            try:
-                self.value = ''.join(chr(reg) for reg in registers)
-            except ValueError:
-                self.value = ''
+            self.value = b.decode('utf-8', errors='ignore').rstrip('\x00')
 
     def to_raw(self, value, byte_order=ByteOrder.MSB, word_order=WordOrder.NORMAL) -> list[int]:
         # Reverse scaling and offset
@@ -170,7 +167,8 @@ class ModbusDatapoint:
                 b = scaled_value.to_bytes(self.length*2, byteorder='big')
 
         elif self.type == 'string':
-            b = bytes(value.ljust(self.length*2, '\x00'), 'utf-8')
+            b = value.encode('utf-8')
+            b = b.ljust(self.length * 2, b'\x00')
 
         # Apply word swap if needed
         if word_order == WordOrder.SWAP and self.length > 1 and self.type != 'string':


### PR DESCRIPTION
This was bonus code produced while searching for other problems. My understanding is that current string handling doesn't work when two char:s is packed into each 16 bit value, but the solution in this fix should be more universal. 
However...this is generated code (and reasoning below) so please review. I can only confirm it's working for existing strings (like before). 


"The from_raw method now correctly decodes the entire byte stream instead of iterating through registers. This fixes issues with multi-byte characters and padding.\n\nThe to_raw method is updated to match, ensuring robust and universal string support."