### PR TITLE
Implement suggested_display_precision for sensors and apply to MAGNA3

### DIFF
--- a/custom_components/modbus_devices/devices/Grundfos/MAGNA3.py
+++ b/custom_components/modbus_devices/devices/Grundfos/MAGNA3.py
@@ -60,6 +60,7 @@ class Device(ModbusDevice):
                     deviceClass=SensorDeviceClass.VOLUME_FLOW_RATE,
                     stateClass=SensorStateClass.MEASUREMENT,
                     units=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+                    precision=1,
                 ),
             ),
             "Relative Performance": ModbusDatapoint(

--- a/custom_components/modbus_devices/sensor.py
+++ b/custom_components/modbus_devices/sensor.py
@@ -36,6 +36,7 @@ class ModbusSensorEntity(ModbusBaseEntity, SensorEntity):
         self._attr_device_class = modbusDataPoint.entity_data.deviceClass
         self._attr_state_class = modbusDataPoint.entity_data.stateClass
         self._attr_native_unit_of_measurement = modbusDataPoint.entity_data.units
+        self._attr_suggested_display_precision = modbusDataPoint.entity_data.precision
 
         """Cusom Entity properties"""
         self.enum = modbusDataPoint.entity_data.enum


### PR DESCRIPTION
Generally I think default precision works very well, but I found one case where I really like to pass along this to ha:s "suggested precision". In this case it's for volume flow for Magna3, that is in m3 and is low in my case (1-2) and HA by default rounds this two a whole number but I think it's much better to display 1.6 rather than "2".

I think this is a trivial change to the framework and could be both needed and used by other subintegrations.

IMPORTANT:
I THINK you need to first apply my general pull request for MAGNA3 first to avoid conflicts.

But I'd prefer to put this as a separate PR since it makes changes to the framework.
